### PR TITLE
Fix migration of the postgres DB

### DIFF
--- a/migrations/1_initial.go
+++ b/migrations/1_initial.go
@@ -9,11 +9,11 @@ type user struct {
 	ID              int
 	Username        string            `sql:"username,notnull,unique"`
 	Token           string            `sql:"token"`
-	ExtraProperties map[string]string `sql:"extraProperties,hstore"`
+	ExtraProperties map[string]string `sql:"extraProperties" pg:"hstore"`
 }
 
 func init() {
-	migrations.Register(func(db migrations.DB) error {
+	migrations.RegisterTx(func(db migrations.DB) error {
 		err := orm.CreateTable(db, &user{}, &orm.CreateTableOptions{
 			Temp:        false,
 			IfNotExists: true,

--- a/migrations/2_user_lastquery.go
+++ b/migrations/2_user_lastquery.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	migrations.Register(func(db migrations.DB) error {
+	migrations.RegisterTx(func(db migrations.DB) error {
 		_, err := db.Exec(`ALTER TABLE users ADD lastquery timestamptz`)
 		return err
 	}, func(db migrations.DB) error {

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -10,10 +10,7 @@ import (
 func EnsureCurrentSchema(db *pg.DB) error {
 	var oldVersion, newVersion int64
 
-	err := db.RunInTransaction(func(tx *pg.Tx) (err error) {
-		oldVersion, newVersion, err = migrations.Run(tx, "")
-		return
-	})
+	oldVersion, newVersion, err := migrations.Run(db, "up")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With the introduction of go modules we needed a newer version of go-pg.
This version introduced some changes in the schema definition as well as in the migration process.
Running the migration inside a global transaction is currently not possible and therefor split into transactions for each migration (https://github.com/go-pg/migrations/issues/74).